### PR TITLE
Allow Extra Arguments Run Command

### DIFF
--- a/.changelog.d/14.feature.md
+++ b/.changelog.d/14.feature.md
@@ -1,0 +1,1 @@
+Allow extra parameters to be sent with any run command.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You can add scripts to the `scripts` object in the `buddy.json` file.
 You can run these scripts using the `buddy run` command.
 
 ```bash
-buddy run <script-name>
+buddy run <script-name> <args>
 
 buddy <script-name> # Shorthand notation (cannot be used if it overlaps with existing `buddy` commands)
 ```

--- a/buddy.json
+++ b/buddy.json
@@ -7,6 +7,7 @@
 		"build": "go build -o ./dist/buddy",
 		"run": "./dist/buddy --version",
 		"build:run": "./dist/buddy run build && ./dist/buddy run run",
-		"install": "go install ."
+		"install": "go install .",
+		"echo": "echo"
 	}
 }

--- a/buddy.json
+++ b/buddy.json
@@ -1,6 +1,6 @@
 {
 	"name": "buddy",
-	"version": "0.0.1-beta.2",
+	"version": "vx.x.x",
 	"description": "A CLI to help automate your development workflow.",
 	"author": "dreadster3",
 	"scripts": {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -15,8 +15,9 @@ func init() {
 }
 
 var initCmd = &cobra.Command{
-	Use:   "init [flags] [directory]",
-	Short: "Initialize a new buddy file",
+	Use:                   "init [options] [directory]",
+	DisableFlagsInUseLine: true,
+	Short:                 "Initialize a new buddy file",
 	Long: `Initialize a new buddy file.
 	If a directory is provided, buddy.json will be created in the directory.
 	If no directory is provided, buddy.json will be created in the current directory.`,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,7 +9,7 @@ var buddyCmd = &cobra.Command{
 	Use:                   "buddy [options] [command]",
 	DisableFlagsInUseLine: true,
 	Short:                 "buddy is a CLI tool to help you automate your development workflow",
-	Version:               "0.0.1-beta01",
+	Version:               "0.0.1-beta03",
 	Args:                  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		commandName := args[0]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,10 +6,11 @@ import (
 )
 
 var buddyCmd = &cobra.Command{
-	Use:     "buddy",
-	Short:   "buddy is a CLI tool to help you automate your development workflow",
-	Version: "0.0.1-beta01",
-	Args:    cobra.MaximumNArgs(1),
+	Use:                   "buddy [options] [command]",
+	DisableFlagsInUseLine: true,
+	Short:                 "buddy is a CLI tool to help you automate your development workflow",
+	Version:               "0.0.1-beta01",
+	Args:                  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		commandName := args[0]
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -7,39 +7,88 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var listCommands bool
+type RunOptions struct {
+	// Args
+	CommandName string
+	CommandArgs []string
 
-func init() {
-	runCmd.Flags().BoolVarP(&listCommands, "list", "l", false, "List all available commands")
-	buddyCmd.AddCommand(runCmd)
+	// Flags
+	ListCommands bool
 }
 
-var runCmd = &cobra.Command{
-	Use:   "run [flags] [command]",
-	Short: "Run a predefined command",
-	Long:  `Run a predefined command`,
-	Args:  cobra.MaximumNArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if listCommands || len(args) == 0 {
+func init() {
+	buddyCmd.AddCommand(NewCmdRun())
+}
+
+func NewCmdRun() *cobra.Command {
+	opts := &RunOptions{}
+
+	var runCmd = &cobra.Command{
+		Use:                   "run [options] [command] [args...]",
+		DisableFlagsInUseLine: true,
+		Short:                 "Run a predefined command",
+		Long:                  `Run a predefined command`,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 || opts.ListCommands {
+				return nil
+			}
+
 			buddyConfig, err := models.ParseBuddyConfigFile("buddy.json")
 			if err != nil {
 				return err
 			}
 
-			for commandName := range buddyConfig.Scripts {
-				fmt.Println(commandName, "->", buddyConfig.Scripts[commandName])
+			if _, ok := buddyConfig.Scripts[args[0]]; !ok {
+				return fmt.Errorf("Command %s not found", args[0])
 			}
 
 			return nil
+		},
+		Aliases: []string{"execute"},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			buddyConfig, err := models.ParseBuddyConfigFile("buddy.json")
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveError
+			}
+
+			var commands []string
+
+			for commandName := range buddyConfig.Scripts {
+				commands = append(commands, commandName)
+			}
+
+			return commands, cobra.ShellCompDirectiveNoFileComp
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				opts.ListCommands = true
+			} else {
+				opts.CommandName = args[0]
+				opts.CommandArgs = args[1:]
+			}
+
+			return runExecute(opts)
+		},
+	}
+
+	runCmd.Flags().BoolVarP(&opts.ListCommands, "list", "l", false, "List all available commands")
+
+	return runCmd
+}
+
+func runExecute(opts *RunOptions) error {
+	buddyConfig, err := models.ParseBuddyConfigFile("buddy.json")
+	if err != nil {
+		return err
+	}
+
+	if opts.ListCommands {
+		for commandName := range buddyConfig.Scripts {
+			fmt.Println(commandName, "->", buddyConfig.Scripts[commandName])
 		}
 
-		commandName := args[0]
+		return nil
+	}
 
-		buddyConfig, err := models.ParseBuddyConfigFile("buddy.json")
-		if err != nil {
-			return err
-		}
-
-		return buddyConfig.RunScript(commandName)
-	},
+	return buddyConfig.RunScriptArgs(opts.CommandName, opts.CommandArgs)
 }

--- a/models/BuddyConfig.go
+++ b/models/BuddyConfig.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 type BuddyConfig struct {
@@ -47,10 +48,16 @@ func ParseBuddyConfigFile(filePath string) (*BuddyConfig, error) {
 }
 
 func (buddyConfig *BuddyConfig) RunScript(scriptName string) error {
+	return buddyConfig.RunScriptArgs(scriptName, []string{})
+}
+
+func (buddyConfig *BuddyConfig) RunScriptArgs(scriptName string, arguments []string) error {
 	command, ok := buddyConfig.Scripts[scriptName]
 	if !ok {
 		return fmt.Errorf("Script %s not found", scriptName)
 	}
+
+	command = fmt.Sprintf("%s %s", command, strings.Join(arguments, " "))
 
 	execCommand := exec.Command("sh", "-c", command)
 	execCommand.Stdout = os.Stdout


### PR DESCRIPTION
Allow run command to be called with extra arguments, for example:
```json
{
  ...
  "scripts": {
    "echo": "echo"
  }
}
```
Can be called like so:
```bash
buddy run echo "Hello World"
# Output: Hello World
```
---
Closes #5 